### PR TITLE
Added qscale option for ffmpeg to control thumbnail quality

### DIFF
--- a/Nick.Plugin.Jellyscrub/Configuration/PluginConfiguration.cs
+++ b/Nick.Plugin.Jellyscrub/Configuration/PluginConfiguration.cs
@@ -71,6 +71,12 @@ public class PluginConfiguration : BasePluginConfiguration
     public HashSet<int> WidthResolutions { get; set; } = new HashSet<int> { 320 };
 
     /// <summary>
+    /// FFmpeg qscale value.
+    /// The lower the value, the better the quality
+    /// </summary>
+    public int QscaleValue { get; set; } = 3;
+
+    /// <summary>
     /// Set the number of threads to be used by ffmpeg.
     /// -1 = use default from jellyfin
     /// 0 = default used by ffmpeg

--- a/Nick.Plugin.Jellyscrub/Configuration/PluginConfiguration.cs
+++ b/Nick.Plugin.Jellyscrub/Configuration/PluginConfiguration.cs
@@ -74,7 +74,7 @@ public class PluginConfiguration : BasePluginConfiguration
     /// FFmpeg qscale value.
     /// The lower the value, the better the quality
     /// </summary>
-    public int QscaleValue { get; set; } = 3;
+    public int QscaleValue { get; set; } = 0;
 
     /// <summary>
     /// Set the number of threads to be used by ffmpeg.

--- a/Nick.Plugin.Jellyscrub/Configuration/configPage.html
+++ b/Nick.Plugin.Jellyscrub/Configuration/configPage.html
@@ -80,6 +80,13 @@
                     </div>
 
                     <div class="inputContainer">
+                        <input is="emby-input" type="number" id="qscaleValue" pattern="[2-6]" min="2" max="6" label="FFmpeg Qscale">
+                        <div class="fieldDescription">Value to pass to the "-qscale:v" argument of ffmpeg from <strong>2-6</strong>.</div>
+                        <div class="fieldDescription">A lower value results in higher quality and will take up more space.</div>
+                        <div class="fieldDescription">If you want the bif files to take up less space, try increasing this value.</div>
+                    </div>
+
+                    <div class="inputContainer">
                         <select is="emby-select" id="processPriority" name="Process Priority" label="Process Priority">
                             <!--<option id="optPriorityRealtime" value="Realtime">Realtime</option>-->
                             <option id="optPriorityHigh" value="High">High</option>
@@ -153,6 +160,7 @@
                         // page.querySelector('#chkStyleTrickplayContainer').checked = config.StyleTrickplayContainer;
                         page.querySelector('#intervalInput').value = config.Interval;
                         page.querySelector('#resolutionInput').value = fromIntArray(config.WidthResolutions);
+                        page.querySelector('#qscaleValue').value = config.QscaleValue;
                         page.querySelector('#processPriority').value = config.ProcessPriority;
                         page.querySelector('#processThreads').value = config.ProcessThreads;
 
@@ -176,6 +184,7 @@
                         // config.StyleTrickplayContainer = page.querySelector('#chkStyleTrickplayContainer').checked;
                         config.Interval = Math.max(0, form.querySelector('#intervalInput').value);
                         config.WidthResolutions = toIntArray(form.querySelector('#resolutionInput').value);
+                        config.QscaleValue= form.querySelector('#qscaleValue').value;
                         config.ProcessPriority = form.querySelector('#processPriority').value;
                         config.ProcessThreads = form.querySelector('#processThreads').value;
 

--- a/Nick.Plugin.Jellyscrub/Configuration/configPage.html
+++ b/Nick.Plugin.Jellyscrub/Configuration/configPage.html
@@ -80,10 +80,18 @@
                     </div>
 
                     <div class="inputContainer">
-                        <input is="emby-input" type="number" id="qscaleValue" pattern="[2-6]" min="2" max="6" label="FFmpeg Qscale">
-                        <div class="fieldDescription">Value to pass to the "-qscale:v" argument of ffmpeg from <strong>2-6</strong>.</div>
-                        <div class="fieldDescription">A lower value results in higher quality and will take up more space.</div>
-                        <div class="fieldDescription">If you want the bif files to take up less space, try increasing this value.</div>
+                        <select is="emby-select" id="qscaleValue" name="Thumbnail Quality" label="Thumbnail Quality">
+                            <option id="opt0" value=0>Disabled</option>
+                            <option id="opt2" value=2>2</option>
+                            <option id="opt3" value=3>3</option>
+                            <option id="opt4" value=4>4</option>
+                            <option id="opt5" value=5>5</option>
+                            <option id="opt6" value=6>6</option>
+                        </select>
+                        <div class="fieldDescription">This setting controls the thumbnail quality by passing a value <strong>between 2 and 6</strong> to the "-qscale" argument of ffmpeg.</div>
+                        <div class="fieldDescription">By default this setting will not be used which roughly equals a "-qscale" value of 2.</div>
+                        <div class="fieldDescription">A higher value means lower quality and a lower value means higher quality.</div>
+                        <div class="fieldDescription">If you want the .bif files to take up less space, try setting a value of 3 or higher.</div>
                     </div>
 
                     <div class="inputContainer">

--- a/Nick.Plugin.Jellyscrub/Drawing/OldMediaEncoder.cs
+++ b/Nick.Plugin.Jellyscrub/Drawing/OldMediaEncoder.cs
@@ -29,6 +29,7 @@ public class OldMediaEncoder
 
     private string _ffmpegPath;
     private int _threads;
+    private int _qscaleValue;
     private readonly PluginConfiguration _config;
 
     public OldMediaEncoder(
@@ -44,6 +45,7 @@ public class OldMediaEncoder
 
         _config = JellyscrubPlugin.Instance!.Configuration;
         var configThreads = _config.ProcessThreads;
+        var configQscaleValue = _config.QscaleValue;
 
         var encodingConfig = _configurationManager.GetEncodingOptions();
         _ffmpegPath = _mediaEncoder.EncoderPath;
@@ -55,6 +57,7 @@ public class OldMediaEncoder
         }
 
         _threads = configThreads == -1 ? EncodingHelper.GetNumberOfThreads(null, encodingConfig, null) : configThreads;
+        _qscaleValue = configQscaleValue
     }
 
     public async Task ExtractVideoImagesOnInterval(
@@ -87,7 +90,7 @@ public class OldMediaEncoder
         Directory.CreateDirectory(targetDirectory);
         var outputPath = Path.Combine(targetDirectory, filenamePrefix + "%08d.jpg");
 
-        var args = string.Format(CultureInfo.InvariantCulture, "-threads {3} -i {0} -threads {4} -v quiet {2} -f image2 \"{1}\"", inputArgument, outputPath, vf, _threads, _threads);
+        var args = string.Format(CultureInfo.InvariantCulture, "-threads {3} -i {0} -threads {4} -v quiet {2} -qscale:v {5} -f image2 \"{1}\"", inputArgument, outputPath, vf, _threads, _threads, _qscaleValue);
 
         if (!string.IsNullOrWhiteSpace(container))
         {

--- a/Nick.Plugin.Jellyscrub/Drawing/OldMediaEncoder.cs
+++ b/Nick.Plugin.Jellyscrub/Drawing/OldMediaEncoder.cs
@@ -57,7 +57,7 @@ public class OldMediaEncoder
         }
 
         _threads = configThreads == -1 ? EncodingHelper.GetNumberOfThreads(null, encodingConfig, null) : configThreads;
-        _qscaleValue = configQscaleValue
+        _qscaleValue = configQscaleValue;
     }
 
     public async Task ExtractVideoImagesOnInterval(
@@ -90,7 +90,14 @@ public class OldMediaEncoder
         Directory.CreateDirectory(targetDirectory);
         var outputPath = Path.Combine(targetDirectory, filenamePrefix + "%08d.jpg");
 
-        var args = string.Format(CultureInfo.InvariantCulture, "-threads {3} -i {0} -threads {4} -v quiet {2} -qscale:v {5} -f image2 \"{1}\"", inputArgument, outputPath, vf, _threads, _threads, _qscaleValue);
+        var args = string.Format(CultureInfo.InvariantCulture, "-threads {2} -i {0} -threads {2} -v quiet {1} -f image2", inputArgument, vf, _threads);
+
+        if (_qscaleValue != 0)
+        {
+            args = args + " " + string.Format(CultureInfo.InvariantCulture, "-qscale:v {0}", _qscaleValue);
+        }
+
+        args = args + " " + string.Format(CultureInfo.InvariantCulture, "\"{0}\"", outputPath);
 
         if (!string.IsNullOrWhiteSpace(container))
         {


### PR DESCRIPTION
I added the option to set a qscale value for ffmpeg in the settings of the plugin, because I wanted to save a bit of drive space.
The options are values from 2 to 6 or to disable the setting.
By default the setting is disabled, so existing and new users are not forced to use it.

Here is an example of no qscale vs. qscale set to 4, using Harry Potter and the Order of the Phoenix:

![image](https://user-images.githubusercontent.com/96189976/207938766-a2b45232-4e76-483c-b4d1-e2aee24ae3b0.png)

In terms of quality I don't really notice a difference up until 6, but that may vary depending on screen size.
I am using a 1080p 24 inch Monitor and my Smartphone.