### PR TITLE
added possibility to start multiple parallel processes when encoding …

### DIFF
--- a/Nick.Plugin.Jellyscrub/Api/TrickplayController.cs
+++ b/Nick.Plugin.Jellyscrub/Api/TrickplayController.cs
@@ -116,7 +116,7 @@ public class TrickplayController : ControllerBase
             else if (_config.OnDemandGeneration)
             {
                 _ = new VideoProcessor(_loggerFactory, _loggerFactory.CreateLogger<VideoProcessor>(), _mediaEncoder, _configurationManager, _fileSystem, _appPaths, _libraryMonitor, _encodingHelper)
-                    .Run(item, CancellationToken.None).ConfigureAwait(false);
+                    .Run(item, false, CancellationToken.None).ConfigureAwait(false);
                 return StatusCode(503);
             }
         }
@@ -154,7 +154,7 @@ public class TrickplayController : ControllerBase
             else if (_config.OnDemandGeneration && _config.WidthResolutions.Contains(width))
             {
                 _ = new VideoProcessor(_loggerFactory, _loggerFactory.CreateLogger<VideoProcessor>(), _mediaEncoder, _configurationManager, _fileSystem, _appPaths, _libraryMonitor, _encodingHelper)
-                    .Run(item, CancellationToken.None).ConfigureAwait(false);
+                    .Run(item, false, CancellationToken.None).ConfigureAwait(false);
                 return StatusCode(503);
             }
         }

--- a/Nick.Plugin.Jellyscrub/Configuration/PluginConfiguration.cs
+++ b/Nick.Plugin.Jellyscrub/Configuration/PluginConfiguration.cs
@@ -79,6 +79,11 @@ public class PluginConfiguration : BasePluginConfiguration
     public int[] WidthResolutions { get; set; } = new[] { 320 };
 
     /// <summary>
+    /// Gets or sets the number of parallel processes used to generate the images.
+    /// </summary>
+    public int ParallelProcesses { get; set; } = 1;
+
+    /// <summary>
     /// Set the number of threads to be used by ffmpeg.
     /// -1 = use default from jellyfin
     /// 0 = default used by ffmpeg

--- a/Nick.Plugin.Jellyscrub/Configuration/configPage.html
+++ b/Nick.Plugin.Jellyscrub/Configuration/configPage.html
@@ -66,7 +66,7 @@
                         <div class="fieldDescription checkboxFieldDescription"><strong>Especially ideal for Docker/combo installs. Recommended to be kept on.</strong></div>
                     </div>
 
-                    <!--
+    <!--
     <div class="checkboxContainer checkboxContainer-withDescription">
         <label>
             <input is="emby-checkbox" type="checkbox" id="chkStyleTrickplayContainer" />
@@ -102,6 +102,13 @@
                         <div class="fieldDescription">Setting this lower or higher will determine how the CPU prioritizes the ffmpeg .bif generation process in relation to other processes.</div>
                         <div class="fieldDescription">If you notice slowdown while generating BIFs but don't want to fully stop their generation, try lowering this as well as the thread count.</div>
                         <!--<div class="fieldDescription"><strong>Note:</strong> Setting this to Realtime might freeze the PC during bif generation!</div>-->
+                    </div>
+
+                    <div class="inputContainer">
+                        <input is="emby-input" type="number" id="parallelProcesses" pattern="[0-9]*" required="" label="Parallel Processes">
+                        <div class="fieldDescription">The number parallel processes started. This will generate trickplay images in parallel.</div>
+                        <div class="fieldDescription"><strong>NOTE: </strong>If using HW Encoding make sure the GPU driver allows the number of entered parallel processes.</div>
+
                     </div>
 
                     <div class="inputContainer">
@@ -167,6 +174,7 @@
                         page.querySelector('#resolutionInput').value = fromIntArray(config.WidthResolutions);
                         page.querySelector('#processPriority').value = config.ProcessPriority;
                         page.querySelector('#processThreads').value = config.ProcessThreads;
+                        page.querySelector('#parallelProcesses').value = config.ParallelProcesses;
 
                         Dashboard.hideLoadingMsg();
                     });
@@ -190,6 +198,7 @@
                         config.WidthResolutions = toIntArray(form.querySelector('#resolutionInput').value);
                         config.ProcessPriority = form.querySelector('#processPriority').value;
                         config.ProcessThreads = form.querySelector('#processThreads').value;
+                        config.ParallelProcesses = form.querySelector('#parallelProcesses').value;
 
                         ApiClient.updatePluginConfiguration(pluginId, config).then(Dashboard.processPluginConfigurationUpdateResult);
                     });

--- a/Nick.Plugin.Jellyscrub/Drawing/OldMediaEncoder.cs
+++ b/Nick.Plugin.Jellyscrub/Drawing/OldMediaEncoder.cs
@@ -36,10 +36,10 @@ public class OldMediaEncoder
     private bool _doHwEncode;
 
     public OldMediaEncoder(
-	    ILogger<OldMediaEncoder> logger,
-	    IMediaEncoder mediaEncoder,
-	    IServerConfigurationManager configurationManager,
-	    IFileSystem fileSystem,
+        ILogger<OldMediaEncoder> logger,
+        IMediaEncoder mediaEncoder,
+        IServerConfigurationManager configurationManager,
+        IFileSystem fileSystem,
         EncodingHelper encodingHelper)
     {
         _logger = logger;

--- a/Nick.Plugin.Jellyscrub/Drawing/VideoProcessor.cs
+++ b/Nick.Plugin.Jellyscrub/Drawing/VideoProcessor.cs
@@ -22,6 +22,7 @@ public class VideoProcessor
     private readonly PluginConfiguration _config;
     private readonly OldMediaEncoder _oldEncoder;
 
+
     public VideoProcessor(
         ILoggerFactory loggerFactory,
         ILogger<VideoProcessor> logger,
@@ -43,12 +44,11 @@ public class VideoProcessor
     /*
      * Entry point to tell VideoProcessor to generate BIF from item
      */
-    public async Task Run(BaseItem item, CancellationToken cancellationToken)
+    public async Task Run(BaseItem item, bool runParallel, CancellationToken cancellationToken)
     {
         if (!EnableForItem(item, _fileSystem, _config.Interval)) return;
 
-        var mediaSources = ((IHasMediaSources)item).GetMediaSources(false)
-            .ToList();
+        var mediaSources = ((IHasMediaSources)item).GetMediaSources(false).ToList();
 
         foreach (var mediaSource in mediaSources)
         {
@@ -62,16 +62,19 @@ public class VideoProcessor
                 if (!item.Id.Equals(Guid.Parse(mediaSource.Id))) continue;
 
                 cancellationToken.ThrowIfCancellationRequested();
-                await Run(item, mediaSource, width, _config.Interval, cancellationToken).ConfigureAwait(false);
+                await Run(item, mediaSource, width, _config.Interval, runParallel, cancellationToken).ConfigureAwait(false);
             }
         }
     }
 
-    private async Task Run(BaseItem item, MediaSourceInfo mediaSource, int width, int interval, CancellationToken cancellationToken)
+    private static readonly SemaphoreSlim _bifWriterSemaphore = new SemaphoreSlim(1, 1);
+
+    private async Task Run(BaseItem item, MediaSourceInfo mediaSource, int width, int interval, bool runParallel, CancellationToken cancellationToken)
     {
         if (!HasBif(item, _fileSystem, width))
         {
-            await BifWriterSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+            if (!runParallel)
+                await _bifWriterSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
 
             try
             {
@@ -87,7 +90,8 @@ public class VideoProcessor
             }
             finally
             {
-                BifWriterSemaphore.Release();
+                if (!runParallel)
+                    _bifWriterSemaphore.Release();
             }
         }
     }
@@ -174,7 +178,8 @@ public class VideoProcessor
     private async Task CreateManifest(BaseItem item, int width)
     {
         // Create Manifest object with new resolution
-        Manifest newManifest = new Manifest() {
+        Manifest newManifest = new Manifest()
+        {
             Version = JellyscrubPlugin.Instance!.Version.ToString(),
             WidthResolutions = new[] { width }
         };
@@ -235,7 +240,6 @@ public class VideoProcessor
     /*
      * Bif Creation
      */
-    private static readonly SemaphoreSlim BifWriterSemaphore = new SemaphoreSlim(1, 1);
 
     private Task CreateBif(BaseItem item, int width, int interval, MediaSourceInfo mediaSource, CancellationToken cancellationToken)
     {

--- a/Nick.Plugin.Jellyscrub/Providers/BIFMetadataProvider.cs
+++ b/Nick.Plugin.Jellyscrub/Providers/BIFMetadataProvider.cs
@@ -108,11 +108,11 @@ public class BIFMetadataProvider : ICustomMetadataProvider<Episode>,
             switch (config.ScanBehavior)
             {
                 case MetadataScanBehavior.Blocking:
-                    await videoProcessor.Run(item, cancellationToken).ConfigureAwait(false);
+                    await videoProcessor.Run(item, false, cancellationToken).ConfigureAwait(false);
                     break;
                 default:
                 case MetadataScanBehavior.NonBlocking:
-                    _ = videoProcessor.Run(item, cancellationToken).ConfigureAwait(false);
+                    _ = videoProcessor.Run(item, false, cancellationToken).ConfigureAwait(false);
                     break;
             }
         }


### PR DESCRIPTION
Added the possibility to configure a number of parallel processes to be started when creating trickplay for the whole library. This can speed up the calculation. The default number of processes is 1 and is configurable via the configuration page.
